### PR TITLE
Don't trigger error when peer/message already exists in buffer

### DIFF
--- a/pkg/bmmc/bmmc.go
+++ b/pkg/bmmc/bmmc.go
@@ -131,8 +131,8 @@ func (b *BMMC) AddMessage(msg any, callbackType string) error {
 
 // AddPeer adds new peer in peers buffer.
 func (b *BMMC) AddPeer(p string) error {
-	if err := b.peerBuffer.AddPeer(p); err != nil {
-		return fmt.Errorf(addPeerErrFmt, p, err)
+	if added := b.peerBuffer.AddPeer(p); !added {
+		return nil
 	}
 
 	msg, err := buffer.NewElement(p, callback.ADDPEER, true)

--- a/pkg/bmmc/bmmc.go
+++ b/pkg/bmmc/bmmc.go
@@ -62,7 +62,7 @@ func New(cfg *Config) (*BMMC, error) {
 	// fill optional fields of the config
 	cfg.fillEmptyFields()
 
-	cfg.Logger.With("host", cfg.Host.String())
+	cfg.Logger = cfg.Logger.With("host", cfg.Host.String())
 
 	// set callbacks
 	callbacksRegistry, err := callback.NewRegistry(cfg.Callbacks)

--- a/pkg/bmmc/gossiper_test.go
+++ b/pkg/bmmc/gossiper_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Gossiper", func() {
 
 		BeforeEach(func() {
 			peerBuf := peer.NewPeerBuffer()
-			Expect(peerBuf.AddPeer("localhost/19999")).To(Succeed())
+			Expect(peerBuf.AddPeer("localhost/19999")).To(BeTrue())
 
 			msgBuf := buffer.NewBuffer(25)
 

--- a/pkg/internal/buffer/buffer.go
+++ b/pkg/internal/buffer/buffer.go
@@ -24,7 +24,6 @@ import (
 
 var (
 	errIndexOutOfRange = errors.New("index out of range")
-	errAlreadyExists   = errors.New("already exists")
 	errTooOldElement   = errors.New("element is too old and buffer is full")
 )
 
@@ -96,7 +95,7 @@ func (buf *Buffer) Add(el Element) error {
 	defer buf.Mux.Unlock()
 
 	if e, _ := buf.contains(el); e {
-		return errAlreadyExists
+		return nil
 	}
 
 	pos, err := buf.elementPosition(el)

--- a/pkg/internal/buffer/buffer_test.go
+++ b/pkg/internal/buffer/buffer_test.go
@@ -290,13 +290,13 @@ var _ = Describe("Buffer interface", func() {
 			Expect(buf.Elements).To(Equal(expectedElements))
 		})
 
-		It("returns error when buffer already contains given element", func() {
+		It("doesn't return error when buffer already contains the given element", func() {
 			el := Element{
 				Timestamp: time.Date(2016, time.October, 29, 0, 0, 0, 0, time.UTC),
 				ID:        "2016",
 			}
 
-			Expect(buf.Add(el)).To(MatchError(errAlreadyExists))
+			Expect(buf.Add(el)).To(Succeed())
 		})
 	})
 

--- a/pkg/internal/callback/peer_callback.go
+++ b/pkg/internal/callback/peer_callback.go
@@ -55,8 +55,10 @@ func AddPeerCallback(data any, logger *slog.Logger) error {
 	}
 
 	// add peer in buffer
-	if err := peerCBData.Buffer.AddPeer(p); err != nil {
-		return err //nolint: wrapcheck
+	if added := peerCBData.Buffer.AddPeer(p); !added {
+		logger.Debug("peer already exists", "peer", p)
+
+		return nil
 	}
 
 	logger.Debug("new peer added", "peer", p)

--- a/pkg/internal/peer/peer_buffer.go
+++ b/pkg/internal/peer/peer_buffer.go
@@ -17,7 +17,6 @@ limitations under the License.
 package peer
 
 import (
-	"fmt"
 	"math/rand"
 	"sync"
 )
@@ -59,17 +58,18 @@ func (peerBuffer *Buffer) alreadyExists(peer string) bool {
 }
 
 // AddPeer adds a peer in peers buffer.
-func (peerBuffer *Buffer) AddPeer(peer string) error {
+// AddPeer returns `false` when the peer already exists in buffer and it wasn't added again.
+func (peerBuffer *Buffer) AddPeer(peer string) bool {
 	peerBuffer.mux.Lock()
 	defer peerBuffer.mux.Unlock()
 
 	if peerBuffer.alreadyExists(peer) {
-		return fmt.Errorf("peer %s already exists in peer buffer", peer) //nolint: goerr113
+		return false
 	}
 
 	peerBuffer.peers = append(peerBuffer.peers, peer)
 
-	return nil
+	return true
 }
 
 // RemovePeer removes a peer from peers buffer.

--- a/pkg/internal/peer/peer_buffer_test.go
+++ b/pkg/internal/peer/peer_buffer_test.go
@@ -107,7 +107,7 @@ var _ = Describe("HTTP Peer Buffer Interface", func() {
 				"localhost/30000",
 			}
 
-			Expect(pBuf.AddPeer(newPeer)).To(Succeed())
+			Expect(pBuf.AddPeer(newPeer)).To(BeTrue())
 			Expect(pBuf.peers).To(ConsistOf(expectedPeers))
 		})
 
@@ -125,7 +125,7 @@ var _ = Describe("HTTP Peer Buffer Interface", func() {
 				"localhost/20000",
 			}
 
-			Expect(pBuf.AddPeer(newPeer)).NotTo(Succeed())
+			Expect(pBuf.AddPeer(newPeer)).To(BeFalse())
 			Expect(pBuf.peers).To(ConsistOf(expectedPeers))
 		})
 	})


### PR DESCRIPTION
fixed #166